### PR TITLE
docker: update & add Github action support

### DIFF
--- a/.github/workflows/container-build-and-push.yml
+++ b/.github/workflows/container-build-and-push.yml
@@ -1,0 +1,109 @@
+name: Container Build and Push
+
+on:
+  push:
+    branches: [ 'ceph-nvmeof' ]
+    tags: [ 'v*.*' ]
+  pull_request:
+    branches: [ 'ceph-nvmeof' ]
+  workflow_dispatch:
+    inputs:
+      OS_RELEASE:
+        description: 'OS Release (UBI/CENTOS)'
+        required: true
+        default: '8'
+        type: choice
+        options:
+        - '8'
+        - '9'
+      pushToRegistry:
+        description: 'Whether to push the resulting image to a registry'
+        required: true
+        default: false
+        type: boolean
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ${{ vars.REGISTRY }}
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+  OS_RELEASE: ${{ inputs.OS_RELEASE || '8' }}
+  SPDK_VERSION: 'v23.01'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Get tags
+        run: git fetch --tags --no-recurse-submodules origin 
+
+#      # Install the cosign tool except on PR
+#      # https://github.com/sigstore/cosign-installer
+#      - name: Install cosign
+#        if: github.event_name != 'pull_request'
+#        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+#        with:
+#          cosign-release: 'v1.13.1'
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 #v2.4.1
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request' && inputs.pushToRegistry
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
+        with:
+          context: .
+          file: ./docker/ubi/Dockerfile
+          build-args: |
+            OS_RELEASE=${{ env.OS_RELEASE }}
+            SPDK_VERSION=${{ env.SPDK_VERSION }}
+          push: ${{ github.event_name != 'pull_request' && inputs.pushToRegistry }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+#      # Sign the resulting Docker image digest except on PRs.
+#      # This will only write to the public Rekor transparency log when the Docker
+#      # repository is public to avoid leaking data.  If you would like to publish
+#      # transparency data even for private images, pass --force to cosign below.
+#      # https://github.com/sigstore/cosign
+#      - name: Sign the published Docker image
+#        if: ${{ github.event_name != 'pull_request' }}
+#        env:
+#          COSIGN_EXPERIMENTAL: "true"
+#        # This step uses the identity token to provision an ephemeral certificate
+#        # against the sigstore community Fulcio instance.
+#        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+#

--- a/docker/ubi/Dockerfile
+++ b/docker/ubi/Dockerfile
@@ -1,0 +1,111 @@
+# syntax = docker/dockerfile:1.4
+ARG OS_RELEASE=8
+FROM registry.access.redhat.com/ubi$OS_RELEASE/ubi:latest as prebase
+ARG OS_RELEASE
+
+# Speed up dnf
+COPY <<EOF /etc/dnf/dnf.conf
+[main]
+gpgcheck=1
+installonly_limit=3
+clean_requirements_on_remove=True
+skip_if_unavailable=False
+best=False
+fastestmirror=True
+max_parallel_downloads=10
+tsflags=nodocs
+EOF
+
+#------------------------------------------------------------------------------
+FROM prebase as base_release_8
+ARG CENTOS_PACKAGE_VERSION="8-6"
+ARG CENTOS_MIRROR="mirror.centos.org/centos"
+
+#------------------------------------------------------------------------------
+FROM prebase as base_release_9
+ARG CENTOS_PACKAGE_VERSION="9.0-20"
+ARG CENTOS_MIRROR="mirror.stream.centos.org"
+
+#------------------------------------------------------------------------------
+FROM base_release_$OS_RELEASE as base
+
+ARG CENTOS_URL="http://$CENTOS_MIRROR/$OS_RELEASE-stream/BaseOS/x86_64/os/Packages"
+ARG CENTOS_GPG_PACKAGE="$CENTOS_URL/centos-gpg-keys-$CENTOS_PACKAGE_VERSION.el$OS_RELEASE.noarch.rpm"
+ARG CENTOS_REPO_PACKAGE="$CENTOS_URL/centos-stream-repos-$CENTOS_PACKAGE_VERSION.el$OS_RELEASE.noarch.rpm"
+
+ARG CEPH_VERSION="17.2.5"
+
+
+COPY <<EOF /etc/yum.repos.d/ceph.repo 
+[Ceph]
+name=Ceph packages for \$basearch
+baseurl=http://download.ceph.com/rpm-$CEPH_VERSION/el\$releasever/\$basearch
+enabled=1
+gpgcheck=1
+type=rpm-md
+gpgkey=https://download.ceph.com/keys/release.asc
+
+[Ceph-noarch]
+name=Ceph noarch packages
+baseurl=http://download.ceph.com/rpm-$CEPH_VERSION/el\$releasever/noarch
+enabled=1
+gpgcheck=1
+type=rpm-md
+gpgkey=https://download.ceph.com/keys/release.asc
+
+[ceph-source]
+name=Ceph source packages
+baseurl=http://download.ceph.com/rpm-$CEPH_VERSION/el\$releasever/SRPMS
+enabled=1
+gpgcheck=1
+type=rpm-md
+gpgkey=https://download.ceph.com/keys/release.asc
+EOF
+
+RUN \
+    --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf remove -y dnf-plugin-subscription-manager \
+    && dnf install -y \
+        $CENTOS_GPG_PACKAGE \
+        $CENTOS_REPO_PACKAGE
+
+#------------------------------------------------------------------------------
+FROM base as build
+
+ARG SPDK_VERSION
+
+ARG RPM_RELEASE
+ARG MAKEFLAGS
+ARG PKGDEP_ARGS="--rbd"
+ARG CONFIGURE_ARGS="\
+  --with-rbd \
+  --disable-tests \
+  --disable-unit-tests \
+  --disable-examples \
+"
+
+WORKDIR /src
+COPY . .
+
+RUN \
+    --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    --mount=type=cache,target=/root/.cache/pip \
+    dnf install -y \
+        rpm-build \
+        git \
+    && scripts/pkgdep.sh $PKGDEP_ARGS
+
+RUN DEPS="no" rpmbuild/rpm.sh $CONFIGURE_ARGS
+
+#------------------------------------------------------------------------------
+FROM base as spdk
+
+# @TODO: Add LABELs
+
+RUN \
+    --mount=type=bind,from=build,source=/root/rpmbuild/rpm,target=/rpm \
+    --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y /rpm/$(uname -m)/*.rpm


### PR DESCRIPTION
The goal of this PR is to automate the creation of the SPDK container image. Additionally it removes dependency on external artifacts (repo files, etc) and relies as much as possible in the scripts provided by the spdk/spdk project.

The container build has the following arguments:
- `CENTOS_VERSION` (UBI actually): supports 8 (default) and 9.
- `SPDK_VERSION`: is mandatory. It follows the pattern `vX.Y` (e.g.: `v21.01`).
- `CEPH_VERSION`: defaults to 17.2.5.

The size of the output image is around 350 MB (in UBI8, with CentOS 8 it grows until 500 MB).

If the Dockerfile and the Github Action are considered useful, this changeset could be proposed to the main `spdk:spdk` repo.