### PR TITLE
test/memory_ut: fix clang compilation error

### DIFF
--- a/test/env/memory/memory_ut.c
+++ b/test/env/memory/memory_ut.c
@@ -51,6 +51,7 @@ DEFINE_STUB(spdk_env_dpdk_external_init, bool, (void), true);
 DEFINE_STUB(rte_mem_event_callback_register, int,
 	    (const char *name, rte_mem_event_callback_t clb, void *arg), 0);
 DEFINE_STUB(rte_mem_virt2iova, rte_iova_t, (const void *virtaddr), 0);
+DEFINE_STUB(rte_eal_iova_mode, enum rte_iova_mode, (void), RTE_IOVA_VA);
 
 static int
 test_mem_map_notify(void *cb_ctx, struct spdk_mem_map *map,


### PR DESCRIPTION
clang reports the following error:

memory_ut.o: In function `vtophys_notify':
/home/spdk/lib/env_dpdk/memory.c:1025: undefined reference to `rte_eal_iova_mode'
/home/spdk/lib/env_dpdk/memory.c:1137: undefined reference to `rte_eal_iova_mode'

Fix issue #1613

Change-Id: Ia7e3e6c1f6f63bf664d6b76ebdc070c2cba76b2d

Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/4686
Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
Community-CI: Mellanox Build Bot
Reviewed-by: Jim Harris <james.r.harris@intel.com>
Reviewed-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
(cherry picked from commit da58e37709cb2a8eafdfec1863f7f846bcd8aad2)