### PR TITLE
rbd: add rados namespace support

### DIFF
--- a/module/bdev/rbd/bdev_rbd.h
+++ b/module/bdev/rbd/bdev_rbd.h
@@ -28,6 +28,7 @@ typedef void (*spdk_delete_rbd_complete)(void *cb_arg, int bdeverrno);
 
 int bdev_rbd_create(struct spdk_bdev **bdev, const char *name, const char *user_id,
 		    const char *pool_name,
+			const char *rados_namespace_name,
 		    const char *const *config,
 		    const char *rbd_name, uint32_t block_size, const char *cluster_name,
 		    const struct spdk_uuid *uuid, bool read_only);

--- a/module/bdev/rbd/bdev_rbd_rpc.c
+++ b/module/bdev/rbd/bdev_rbd_rpc.c
@@ -13,6 +13,7 @@ struct rpc_create_rbd {
 	char *name;
 	char *user_id;
 	char *pool_name;
+	char *rados_namespace_name;
 	char *rbd_name;
 	uint32_t block_size;
 	char **config;
@@ -27,6 +28,7 @@ free_rpc_create_rbd(struct rpc_create_rbd *req)
 	free(req->name);
 	free(req->user_id);
 	free(req->pool_name);
+	free(req->rados_namespace_name);
 	free(req->rbd_name);
 	bdev_rbd_free_config(req->config);
 	free(req->cluster_name);
@@ -78,6 +80,7 @@ static const struct spdk_json_object_decoder rpc_create_rbd_decoders[] = {
 	{"name", offsetof(struct rpc_create_rbd, name), spdk_json_decode_string, true},
 	{"user_id", offsetof(struct rpc_create_rbd, user_id), spdk_json_decode_string, true},
 	{"pool_name", offsetof(struct rpc_create_rbd, pool_name), spdk_json_decode_string},
+	{"rados_namespace_name", offsetof(struct rpc_create_rbd, rados_namespace_name), spdk_json_decode_string, true},
 	{"rbd_name", offsetof(struct rpc_create_rbd, rbd_name), spdk_json_decode_string},
 	{"block_size", offsetof(struct rpc_create_rbd, block_size), spdk_json_decode_uint32},
 	{"config", offsetof(struct rpc_create_rbd, config), bdev_rbd_decode_config, true},
@@ -105,6 +108,7 @@ rpc_bdev_rbd_create(struct spdk_jsonrpc_request *request,
 	}
 
 	rc = bdev_rbd_create(&bdev, req.name, req.user_id, req.pool_name,
+		 		 req.rados_namespace_name,
 			     (const char *const *)req.config,
 			     req.rbd_name,
 			     req.block_size, req.cluster_name, &req.uuid, req.read_only);

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -1067,7 +1067,7 @@ def bdev_rbd_get_clusters_info(client, name=None):
 
 
 def bdev_rbd_create(client, pool_name, rbd_name, block_size, name=None, user_id=None, config=None, cluster_name=None,
-                    uuid=None, read_only=None):
+                    rados_namespace_name=None, uuid=None, read_only=None):
     """Create a Ceph RBD block device.
     Args:
         pool_name: Ceph RBD pool name
@@ -1077,6 +1077,7 @@ def bdev_rbd_create(client, pool_name, rbd_name, block_size, name=None, user_id=
         user_id: Ceph user name (optional)
         config: map of config keys to values (optional)
         cluster_name: Name to identify Rados cluster (optional)
+        rados_namespace_name: RBD namespace name (optional)
         uuid: UUID of block device (optional)
         read_only: set block device to read-only (optional)
     Returns:
@@ -1094,6 +1095,8 @@ def bdev_rbd_create(client, pool_name, rbd_name, block_size, name=None, user_id=
         params['config'] = config
     if cluster_name is not None:
         params['cluster_name'] = cluster_name
+    if rados_namespace_name is not None:
+        params['rados_namespace_name'] = rados_namespace_name
     else:
         print("WARNING:bdev_rbd_create should be used with specifying -c to have a cluster name after bdev_rbd_register_cluster.")
     if uuid is not None:

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -1096,6 +1096,7 @@ def main():
                                             rbd_name=args.rbd_name,
                                             block_size=args.block_size,
                                             cluster_name=args.cluster_name,
+                                            rados_namespace_name=args.rados_namespace_name,
                                             uuid=args.uuid,
                                             read_only=args.read_only))
 
@@ -1106,6 +1107,7 @@ def main():
                    help="adds a key=value configuration option for rados_conf_set (default: rely on config file)")
     p.add_argument('pool_name', help='rbd pool name')
     p.add_argument('rbd_name', help='rbd image name')
+    p.add_argument('rados_namespace_name', help='rados namespace name')
     p.add_argument('block_size', help='rbd block size', type=int)
     p.add_argument('-c', '--cluster-name', help="cluster name to identify the Rados cluster")
     p.add_argument('-u', '--uuid', help="UUID of the bdev")


### PR DESCRIPTION
add another level (hierarchy) between pool and rbd iamge name. it called **RADOS Namespace**
there is no connection between nvmeof namespace and RADOS namespace 
e.g. `my_pool/my_namespace/my_rbd_image.`
